### PR TITLE
Remove devel from sanity and unit tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -45,7 +45,6 @@ jobs:
           - stable-2.13
           - stable-2.14
           - stable-2.15
-          - devel
         # - milestone
     runs-on: ubuntu-latest
     steps:
@@ -82,7 +81,6 @@ jobs:
           - stable-2.13
           - stable-2.14
           - stable-2.15
-          - devel
     steps:
       - name: >-
           Perform unit testing against

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Every voice is important. If you have something on your mind, create an issue or
  * Ansible 2.13
  * Ansible 2.14
  * Ansible 2.15
- * Ansible `devel` branch
 
 ## Tested with SONiC
 


### PR DESCRIPTION
##### SUMMARY

Seems to be broken currently

```
+ python -m pip install 'PyYAML>5,<6' --disable-pip-version-check --user
Collecting PyYAML<6,>5
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 2.9 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error
  
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> [5 lines of output]
      ERROR: Could not find a version that satisfies the requirement setuptools (from versions: none)
      ERROR: No matching distribution found for setuptools
      
Notice:       [notice] A new release of pip is available: 23.0.1 -> 23.1.2
Notice:       [notice] To update, run: pip install --upgrade pip
      [end of output]
  
```
##### ISSUE TYPE

- Bugfix Pull Request
