### PR TITLE
Vlan

### DIFF
--- a/plugins/module_utils/entries.py
+++ b/plugins/module_utils/entries.py
@@ -1,0 +1,24 @@
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from ansible.module_utils.common.dict_transformations import recursive_diff
+
+
+def compare_entries(new, cur):
+    """Compares two config db entries
+
+    If both new and current entries are empty/None return False.
+    If one of the new or the current is empty/None but not the other return True.
+    If both entries have values, compare them and return True if there are any differences.
+    Else return False.
+    """
+    # if both new and cur is empty, both current and wanted state is absent
+    if not new and not cur:
+        return False
+    # if new XOR cur is empty current and wanted state doesn't match
+    elif (not new) != (not cur):
+        return True
+    # diff new and cur, if they are the same recursive_diff will return None
+    if not recursive_diff(new, cur) is None:
+        return True
+    return False

--- a/plugins/modules/vlan.py
+++ b/plugins/modules/vlan.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vlan
+short_description: Configure a SONiC VLANs
+version_added: "0.2.0"
+description: Manage VLANs in SONiC
+options:
+    vlanid:
+        description: The VLAN ID to configure
+        required: true
+        type: int
+    state:
+        description: Whether the VLAN should be present or absent
+        default: present
+        type: str
+        choices: [present, absent]
+    dhcp_servers:
+        description: DHCP servers to relay DHCP packets to
+        type: list
+        elements: str
+        default: []
+
+author:
+    - Erik Larsson (@whooo)
+'''
+
+EXAMPLES = r'''
+# Add a VLAN
+- name: Add VLAN
+  community.sonic.vlan:
+    vlanid: 3600
+
+# Remove a VLAN
+- name: Remove VLAN
+  community.sonic.vlan:
+    vlanid: 3600
+    state: absent
+
+# Add a VLAN with dhcp relay
+- name: VLAN with dhcp servers
+  community.sonic.vlan:
+    vlanid: 3600
+    dhcp_servers:
+      - "10.1.0.2"
+      - "10.1.0.3"
+'''
+
+RETURN = r'''
+interface:
+    description: The VLAN interface name
+    type: str
+    returned: always
+'''
+
+import ipaddress
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.community.sonic.plugins.module_utils.entries import compare_entries
+
+try:
+    from swsscommon import swsscommon
+except ImportError:
+    HAS_SWSSCOMMON_LIBRARY = False
+    SWSSCOMMON_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_SWSSCOMMON_LIBRARY = True
+    SWSSCOMMON_IMPORT_ERROR = None
+
+
+def check_address(address):
+    """Check if an address is an IP address
+
+    Returns False if the ipaddress module is unable to parse the address, True otherwise
+    """
+    try:
+        ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return True
+
+
+def build_vlan_entry(vlanid, state, dhcp_servers):
+    key = f'Vlan{vlanid}'
+    # If state is absent there is no reason to build an entry
+    if state == 'absent':
+        return key, None
+
+    val = {
+        'vlanid': vlanid,
+    }
+    # Split dhcp_servers by IP family to reflect how the config db entry looks
+    dhcpv4_servers = list()
+    dhcpv6_servers = list()
+    for ds in dhcp_servers:
+        addr = ipaddress.ip_address(ds)
+        if isinstance(addr, ipaddress.IPv6Address):
+            dhcpv6_servers.append(ds)
+        else:
+            dhcpv4_servers.append(ds)
+    if len(dhcpv4_servers):
+        val["dhcp_servers"] = dhcpv4_servers
+    if len(dhcpv6_servers):
+        val["dhcpv6_servers"] = dhcpv6_servers
+    return key, val
+
+
+def run_module():
+    module_args = dict(
+        vlanid=dict(type='int', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent'], required=False),
+        dhcp_servers=dict(type='list', elements='str', default=list(), required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # Check all addresses in dhcp_servers so we can provide an good error message
+    for ds in module.params.get('dhcp_servers', []):
+        if not check_address(ds):
+            module.fail_json(msg=f'dhcp server address {ds} is not a valid IP address')
+
+    if not HAS_SWSSCOMMON_LIBRARY:
+        module.fail_json(
+            msg=missing_required_lib('swsscommon'),
+            exception=SWSSCOMMON_IMPORT_ERROR)
+
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+
+    key, val = build_vlan_entry(**module.params)
+    cur_val = config_db.get_entry('VLAN', key)
+    changed = compare_entries(val, cur_val)
+
+    if module.check_mode or not changed:
+        module.exit_json(changed=changed, interface=key)
+
+    config_db.set_entry('VLAN', key, val)
+
+    module.exit_json(changed=changed, interface=key)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vlan_member.py
+++ b/plugins/modules/vlan_member.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vlan_member
+short_description: Configure a SONiC VLAN port memberships
+version_added: "0.2.0"
+description: Manage VLAN port memberships in SONiC
+options:
+    vlanid:
+        description: The VLAN to manage the interface membership for
+        required: true
+        type: int
+    state:
+        description: Whether the interface should be attached to the VLAN or not
+        default: present
+        type: str
+        choices: [present, absent]
+    interface:
+        description: The interface to attach to the VLAN
+        required: true
+        type: str
+    tagged:
+        description: Whether the VLAN should be tagged for the interface or not, required when I(state=present)
+        type: bool
+
+author:
+    - Erik Larsson (@whooo)
+'''
+
+EXAMPLES = r'''
+# Add an interface to VLAN
+- name: Add interface to VLAN
+  community.sonic.vlan_member:
+    vlanid: 3600
+    interface: Ethernet90
+    tagged: true
+
+# Remove an interface from a VLAN
+- name: Remove interface from VLAN
+  community.sonic.vlan_member:
+    vlanid: 3600
+    state: absent
+    interface: Ethernet90
+
+# Add an untagged interface
+- name: VLAN membership untagged
+  community.sonic.vlan_member:
+    vlanid: 3600
+    interface: Ethernet90
+    tagged: false
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible_collections.community.sonic.plugins.module_utils.entries import compare_entries
+
+try:
+    from swsscommon import swsscommon
+except ImportError:
+    HAS_SWSSCOMMON_LIBRARY = False
+    SWSSCOMMON_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_SWSSCOMMON_LIBRARY = True
+    SWSSCOMMON_IMPORT_ERROR = None
+
+
+def build_vlan_member_entry(vlanid, interface, state, tagged):
+    key = f'Vlan{vlanid}|{interface}'
+    # No reason to build the entry if state is absent
+    if state == 'absent':
+        return key, None
+
+    val = {
+        'tagging_mode': 'tagged' if tagged else 'untagged',
+    }
+    return key, val
+
+
+def run_module():
+    module_args = dict(
+        vlanid=dict(type='int', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent'], required=False),
+        interface=dict(type='str', required=True),
+        tagged=dict(type='bool', required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        # Don't require the tagged option if we want to remove the membership
+        required_if=(('state', 'present', ('tagged',), True),),
+    )
+
+    if not HAS_SWSSCOMMON_LIBRARY:
+        module.fail_json(
+            msg=missing_required_lib('swsscommon'),
+            exception=SWSSCOMMON_IMPORT_ERROR)
+
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+
+    key, val = build_vlan_member_entry(**module.params)
+    cur_val = config_db.get_entry('VLAN_MEMBER', key)
+    changed = compare_entries(val, cur_val)
+
+    if module.check_mode or not changed:
+        module.exit_json(changed=changed)
+
+    config_db.set_entry('VLAN_MEMBER', key, val)
+
+    module.exit_json(changed=changed)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vlan/aliases
+++ b/tests/integration/targets/vlan/aliases
@@ -1,0 +1,1 @@
+network/sonic/group1

--- a/tests/integration/targets/vlan/tasks/main.yaml
+++ b/tests/integration/targets/vlan/tasks/main.yaml
@@ -25,6 +25,81 @@
     that:
       - "'|      3360 |              |         |                | disabled    | 127.0.0.1             |' in vlan_brief_result.stdout"
 
+- name: Add tagged VLAN member
+  community.sonic.vlan_member:
+    vlanid: 3360
+    interface: Ethernet0
+    tagged: true
+  register: add_vlan_member_result
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - add_vlan_member_result is changed
+
+- name: Query the system for vlans
+  ansible.builtin.shell: "show vlan brief"
+  register: vlan_brief_result
+
+- name: Output from system command
+  ansible.builtin.debug:
+    msg: '{{ vlan_brief_result.stdout }}'
+
+- name: Check that the VLAN member has been added
+  ansible.builtin.assert:
+    that:
+      - "'|      3360 |              | Ethernet0 | tagged         | disabled    | 127.0.0.1             |' in vlan_brief_result.stdout"
+
+- name: Change VLAN member to untagged
+  community.sonic.vlan_member:
+    vlanid: 3360
+    interface: Ethernet0
+    tagged: false
+  register: mod_vlan_member_result
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - mod_vlan_member_result is changed
+
+- name: Query the system for vlans
+  ansible.builtin.shell: "show vlan brief"
+  register: vlan_brief_result
+
+- name: Output from system command
+  ansible.builtin.debug:
+    msg: '{{ vlan_brief_result.stdout }}'
+
+- name: Check that the VLAN member has been changed to untagged
+  ansible.builtin.assert:
+    that:
+      - "'|      3360 |              | Ethernet0 | untagged       | disabled    | 127.0.0.1             |' in vlan_brief_result.stdout"
+
+- name: Remove VLAN member
+  community.sonic.vlan_member:
+    vlanid: 3360
+    interface: Ethernet0
+    state: absent
+  register: del_vlan_member_result
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - del_vlan_member_result is changed
+
+- name: Query the system for vlans
+  ansible.builtin.shell: "show vlan brief"
+  register: vlan_brief_result
+
+- name: Output from system command
+  ansible.builtin.debug:
+    msg: '{{ vlan_brief_result.stdout }}'
+
+- name: Check that the VLAN member has been removed
+  ansible.builtin.assert:
+    that:
+      - "'|      3360 |              |         |                | disabled    | 127.0.0.1             |' in vlan_brief_result.stdout"
+
 - name: Remove VLAN
   community.sonic.vlan:
     vlanid: 3360

--- a/tests/integration/targets/vlan/tasks/main.yaml
+++ b/tests/integration/targets/vlan/tasks/main.yaml
@@ -1,0 +1,51 @@
+---
+- name: Add VLAN
+  community.sonic.vlan:
+    vlanid: 3360
+    dhcp_servers:
+      - '127.0.0.1'
+  register: add_vlan_result
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - add_vlan_result is changed
+      - "'Vlan3360' in add_vlan_result.interface"
+
+- name: Query the system for vlans
+  ansible.builtin.shell: "show vlan brief"
+  register: vlan_brief_result
+
+- name: Output from system command
+  ansible.builtin.debug:
+    msg: '{{ vlan_brief_result.stdout }}'
+
+- name: Check that the VLAN has been added
+  ansible.builtin.assert:
+    that:
+      - "'|      3360 |              |         |                | disabled    | 127.0.0.1             |' in vlan_brief_result.stdout"
+
+- name: Remove VLAN
+  community.sonic.vlan:
+    vlanid: 3360
+    state: absent
+  register: remove_vlan_result
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - remove_vlan_result is changed
+      - "'Vlan3360' in remove_vlan_result.interface"
+
+- name: Query the system for vlans
+  ansible.builtin.shell: "show vlan brief"
+  register: vlan_brief_result
+
+- name: Output from system command
+  ansible.builtin.debug:
+    msg: '{{ vlan_brief_result.stdout }}'
+
+- name: Check that the VLAN has been removed
+  ansible.builtin.assert:
+    that:
+      - "'|      3360 |              |         |                | disabled    | 127.0.0.1             |' not in vlan_brief_result.stdout"

--- a/tests/unit/plugins/module_utils/test_utils_entries.py
+++ b/tests/unit/plugins/module_utils/test_utils_entries.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=disallowed-name
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.sonic.plugins.module_utils.entries import compare_entries
+
+
+def test_compare_entries_both_empty():
+    changed = compare_entries(None, {})
+    assert not changed
+
+
+def test_compare_entries_new_empty():
+    cur = {
+        'key': 'value',
+    }
+    changed = compare_entries({}, cur)
+    assert changed
+
+
+def test_compare_entries_cur_empty():
+    new = {
+        'key': 'value',
+    }
+    changed = compare_entries(new, None)
+    assert changed
+
+
+def test_compare_entries_same():
+    new = {
+        'key': 'value',
+    }
+    cur = {
+        'key': 'value',
+    }
+    changed = compare_entries(new, cur)
+    assert not changed
+
+
+def test_compare_entries_different():
+    new = {
+        'key': 'value',
+    }
+    cur = {
+        'key': 'other value',
+    }
+    changed = compare_entries(new, cur)
+    assert changed

--- a/tests/unit/plugins/modules/test_vlan.py
+++ b/tests/unit/plugins/modules/test_vlan.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=disallowed-name
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.sonic.plugins.modules import vlan
+
+
+def test_check_address():
+    is_addr6 = vlan.check_address('2002::1')
+    assert is_addr6
+    is_addr4 = vlan.check_address('127.0.1.2')
+    assert is_addr4
+    is_addr_bad = vlan.check_address('falafel')
+    assert not is_addr_bad
+
+
+def test_build_vlan_entry_present():
+    key, val = vlan.build_vlan_entry(vlanid=3360, state='present', dhcp_servers=['127.0.0.1', '::1'])
+    assert key == 'Vlan3360'
+    assert val.get('vlanid') == 3360
+    assert val.get('dhcp_servers') == ['127.0.0.1']
+    assert val.get('dhcpv6_servers') == ['::1']
+
+
+def test_build_vlan_entry_absent():
+    key, val = vlan.build_vlan_entry(vlanid=3360, state='absent', dhcp_servers=['127.0.0.1', '::1'])
+    assert key == 'Vlan3360'
+    assert val is None

--- a/tests/unit/plugins/modules/test_vlan_member.py
+++ b/tests/unit/plugins/modules/test_vlan_member.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=disallowed-name
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.sonic.plugins.modules import vlan_member
+
+
+def test_build_vlan_member_entry_present():
+    key, val = vlan_member.build_vlan_member_entry(vlanid=3360, interface='Ethernet90', state='present', tagged=True)
+    assert key == 'Vlan3360|Ethernet90'
+    assert val['tagging_mode'] == 'tagged'
+
+    key, val = vlan_member.build_vlan_member_entry(vlanid=3360, interface='Ethernet90', state='present', tagged=False)
+    assert key == 'Vlan3360|Ethernet90'
+    assert val['tagging_mode'] == 'untagged'
+
+
+def test_build_vlan_member_entry_absent():
+    key, val = vlan_member.build_vlan_member_entry(vlanid=3360, interface='Ethernet90', state='absent', tagged=None)
+    assert key == 'Vlan3360|Ethernet90'
+    assert val is None


### PR DESCRIPTION
##### SUMMARY
Adds two modules to manage VLANs on SONiC.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vlan

##### ADDITIONAL INFORMATION
Adds two module to be able to manage VLAN configuration.
The reason for splitting the functionality into two modules is that it reflects the configuration database structure (the `VLAN` and `VLAN_MEMBER` tables).
Neither module tries to merge current and wanted configuration but rather overwrites the current configuration, per table entry that is.
