### PR TITLE
Add get_entry module

### DIFF
--- a/plugins/modules/get_entry.py
+++ b/plugins/modules/get_entry.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: get_entry
+short_description: Get table/entry from SONiC configuration database
+version_added: "0.2.0"
+description: Manage VLANs in SONiC
+options:
+    table:
+        description: The table to lookup
+        required: true
+        type: str
+    key:
+        description: The key to look up in table
+        type: str
+
+author:
+    - Erik Larsson (@whooo)
+'''
+
+EXAMPLES = r'''
+# Get table
+- name: get vlan table
+  community.sonic.get_entry:
+    table: VLAN
+
+# Get entry in table
+- name: get entry in vlan table
+  community.sonic.get_entry:
+    table: VLAN
+    key: Vlan3600
+'''
+
+RETURN = r'''
+table:
+    description: The database table
+    type: str
+    returned: always
+key:
+    description: The entry key
+    type: str
+    returned: when a key was passed to the module
+value:
+    description: The database value
+    type: dict
+    returned: always
+'''
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+try:
+    from swsscommon import swsscommon
+except ImportError:
+    HAS_SWSSCOMMON_LIBRARY = False
+    SWSSCOMMON_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_SWSSCOMMON_LIBRARY = True
+    SWSSCOMMON_IMPORT_ERROR = None
+
+
+# get_entry / get_table can return a dict with tuples as keys, so called multi-keys
+# so join the tuple into a string so it can be JSON encoded
+def fix_keys(value):
+    if not isinstance(value, dict):
+        return value
+    new_value = dict()
+    for k, v in value.items():
+        if isinstance(k, tuple):
+            nk = '|'.join(k)
+        else:
+            nk = k
+        new_value[nk] = v
+    return new_value
+
+
+def run_module():
+    module_args = dict(
+        table=dict(type='str', required=True),
+        key=dict(type='str', required=False, no_log=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if not HAS_SWSSCOMMON_LIBRARY:
+        module.fail_json(
+            msg=missing_required_lib('swsscommon'),
+            exception=SWSSCOMMON_IMPORT_ERROR)
+
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+
+    table = module.params.get('table')
+    key = module.params.get('key', None)
+    if key is None:
+        value = config_db.get_table(table)
+    else:
+        value = config_db.get_entry(table, key)
+
+    value = fix_keys(value)
+    rargs = {
+        'changed': False,
+        'table': table,
+        'value': value,
+    }
+    # If the whole table was requested, don't return the key as it will be None
+    if key is not None:
+        rargs['key'] = key
+    module.exit_json(**rargs)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/get_entry/aliases
+++ b/tests/integration/targets/get_entry/aliases
@@ -1,0 +1,1 @@
+network/sonic/group1

--- a/tests/integration/targets/get_entry/tasks/main.yaml
+++ b/tests/integration/targets/get_entry/tasks/main.yaml
@@ -1,0 +1,35 @@
+---
+- name: get DEVICE_METADATA table
+  community.sonic.get_entry:
+    table: DEVICE_METADATA
+  register: table_result
+
+- name: Output from table get_entry
+  ansible.builtin.debug:
+    msg: '{{ table_result }}'
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - table_result is not changed
+      - table_result.table == 'DEVICE_METADATA'
+      - table_result.value
+      - "'key' not in table_result"
+
+- name: get localhost in DEVICE_METADATA table
+  community.sonic.get_entry:
+    table: DEVICE_METADATA
+    key: localhost
+  register: key_result
+
+- name: Output from key get_entry
+  ansible.builtin.debug:
+    msg: '{{ key_result }}'
+
+- name: Check the module returns what we expect
+  ansible.builtin.assert:
+    that:
+      - key_result is not changed
+      - key_result.table == 'DEVICE_METADATA'
+      - key_result.key == 'localhost'
+      - key_result.value.hostname == 'sonic'

--- a/tests/unit/plugins/modules/test_get_entry.py
+++ b/tests/unit/plugins/modules/test_get_entry.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=disallowed-name
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.sonic.plugins.modules import get_entry
+
+
+def test_fix_keys():
+    test_dict = {
+        'not_tuple': 'falafel',
+        ('is', 'tuple'): 'tahini',
+    }
+    new_dict = get_entry.fix_keys(test_dict)
+    assert new_dict.get('not_tuple') == 'falafel'
+    assert new_dict.get('is|tuple') == 'tahini'
+    assert ('is', 'tuple') not in new_dict


### PR DESCRIPTION
##### SUMMARY
This implements a module to query the configuration database. Either a whole table or an entry in a table.
Useful for debugging and together with conditions in playbooks.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
get_entry

