### PR TITLE
Add module to configure interface IP addresses

### DIFF
--- a/plugins/modules/interface_ip.py
+++ b/plugins/modules/interface_ip.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: interface_ip
+short_description: Configure interface IP addresses
+version_added: "0.2.0"
+description: Configures IP addresses for interfaces
+options:
+    interface:
+        description: The interface to manage IP addresses for
+        required: true
+        type: str
+    state:
+        description: Whether the IP addresses should be present or absent
+        default: present
+        type: str
+        choices: [present, absent]
+    addresses:
+        description: The IP addresses to add or remove from the interface including prefix
+        required: true
+        type: list
+        elements: str
+
+author:
+    - Erik Larsson (@whooo)
+'''
+
+EXAMPLES = r'''
+# Add addresses
+- name: Add addresses
+  community.sonic.interface_ip:
+    interface: Loopback0
+    addresses:
+      - '10.2.0.2/24'
+      - '2f00::2/64'
+
+# Remove address
+- name: Remove address
+  community.sonic.interface_ip:
+    interface: Loopback0
+    state: absent
+    addresses:
+      - '2f00::2/64'
+
+'''
+
+RETURN = r'''
+interface:
+    description: The interface being managed
+    type: str
+    returned: always
+addresses:
+    description: The addresses which has been added or removed
+    type: list
+    elements: str
+    returned: always
+'''
+
+# FIXME, return values
+
+import ipaddress
+import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+try:
+    from swsscommon import swsscommon
+except ImportError:
+    HAS_SWSSCOMMON_LIBRARY = False
+    SWSSCOMMON_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_SWSSCOMMON_LIBRARY = True
+    SWSSCOMMON_IMPORT_ERROR = None
+
+
+def get_interface_table(interface):
+    # If the interface name contains a dot it's VLAN subinterface
+    if '.' in interface:
+        return 'VLAN_SUB_INTERFACE'
+    elif interface.startswith('Vlan'):
+        return 'VLAN_INTERFACE'
+    elif interface.startswith('Ethernet'):
+        return 'INTERFACE'
+    elif interface.startswith('PortChannel'):
+        return 'PORTCHANNEL_INTERFACE'
+    elif interface.startswith('Loopback'):
+        return 'LOOPBACK_INTERFACE'
+    return None
+
+
+def is_vlan_member(config_db, interface):
+    table = config_db.get_table('VLAN_MEMBER')
+    for key in table.keys():
+        if not isinstance(key, tuple):
+            continue
+        iface = key[1]  # key is (vlan, interface)
+        if iface == interface:
+            return True
+    return False
+
+
+def get_current_addresses(config_db, table, interface):
+    addresses = set()
+    value = config_db.get_table(table)
+    for key in value:
+        if not isinstance(key, tuple):
+            continue
+        iface, addr = key
+        if iface != interface:
+            continue
+        pa = ipaddress.ip_interface(addr)
+        addresses.add(pa)
+    return addresses
+
+
+def run_module():
+    module_args = dict(
+        interface=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent'], required=False),
+        addresses=dict(type='list', elements='str', required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if not HAS_SWSSCOMMON_LIBRARY:
+        module.fail_json(
+            msg=missing_required_lib('swsscommon'),
+            exception=SWSSCOMMON_IMPORT_ERROR)
+
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+
+    interface = module.params.get('interface')
+    # check for correct interface type and get table
+    table = get_interface_table(interface)
+    if table is None:
+        module.fail_json(msg=f'unsupported interface type for {interface}, only Ethernet, Vlan, PortChannel and Loopback are supported')
+    # check that interface is not a VLAN member
+    if is_vlan_member(config_db, interface):
+        module.fail_json(msg=f'{interface } is a VLAN member')
+    # check addresses and build set so current and wanted addresses can be compared
+    addresses = module.params.get('addresses')
+    wanted_addresses = set()
+    for addr in addresses:
+        try:
+            pa = ipaddress.ip_interface(addr)
+        except ValueError:
+            module.fail_json(msg=f'{addr} is not a valid IP address')
+        wanted_addresses.add(pa)
+    # get current interface addresses
+    current_addresses = get_current_addresses(config_db, table, interface)
+    # compare addresses
+    state = module.params.get('state')
+    if state == 'absent':
+        # when removing, only use addresses both in the database and those passed to the module
+        to_update = current_addresses.intersection(wanted_addresses)
+        value = None
+    else:
+        # when adding, only use addresses not in the database
+        to_update = wanted_addresses.difference(current_addresses)
+        value = {"NULL": "NULL"}
+    to_update = [str(x) for x in to_update]
+    changed = len(to_update) > 0
+    # sonic requires an entry with just the interface as the key to apply the addresses, so add it if it's missing
+    need_interface_key = False
+    if interface not in config_db.get_table(table) and state == 'present':
+        need_interface_key = True
+        changed = True
+
+    if module.check_mode or not changed:
+        module.exit_json(changed=changed, interface=interface, addresses=to_update)
+    # build keys, no need for values
+    keys = list()
+    for addr in to_update:
+        key = (interface, addr)
+        keys.append(key)
+
+    if need_interface_key:
+        config_db.set_entry(table, interface, {"NULL": "NULL"})
+    for key in keys:
+        config_db.set_entry(table, key, value)
+
+    module.exit_json(changed=changed, interface=interface, addresses=to_update)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/interface_ip/aliases
+++ b/tests/integration/targets/interface_ip/aliases
@@ -1,0 +1,1 @@
+network/sonic/group1

--- a/tests/integration/targets/interface_ip/tasks/main.yaml
+++ b/tests/integration/targets/interface_ip/tasks/main.yaml
@@ -1,0 +1,85 @@
+---
+# add IP
+- name: add IP
+  community.sonic.interface_ip:
+    interface: Loopback0
+    addresses:
+      - '254.1.1.1/29'
+  register: add_ip_result
+
+- name: check add IP result
+  ansible.builtin.assert:
+    that:
+      - add_ip_result is changed
+      - add_ip_result.interface == 'Loopback0'
+      - "'254.1.1.1/29' in add_ip_result.addresses"
+
+- name: run show ip interface after add
+  ansible.builtin.shell: "show ip interface"
+  register: show_ip_result
+
+- name: output from show ip interface after add
+  ansible.builtin.debug:
+    msg: '{{ show_ip_result.stdout }}'
+
+- name: check show ip interface output after add
+  ansible.builtin.assert:
+    that:
+      - "'                       254.1.1.1/29                       N/A             N/A' in show_ip_result.stdout"
+
+- name: add same IP
+  community.sonic.interface_ip:
+    interface: Loopback0
+    addresses:
+      - '254.1.1.1/29'
+  register: add_same_ip_result
+
+- name: check add same IP result
+  ansible.builtin.assert:
+    that:
+      - add_same_ip_result is not changed
+      - add_same_ip_result.interface == 'Loopback0'
+      - "'254.1.1.1/29' not in add_same_ip_result.addresses"
+
+- name: remove IP
+  community.sonic.interface_ip:
+    interface: Loopback0
+    state: absent
+    addresses:
+      - '254.1.1.1/29'
+  register: remove_ip_result
+
+- name: check remove IP result
+  ansible.builtin.assert:
+    that:
+      - remove_ip_result is changed
+      - remove_ip_result.interface == 'Loopback0'
+      - "'254.1.1.1/29' in remove_ip_result.addresses"
+
+- name: run show ip interface after remove
+  ansible.builtin.shell: "show ip interface"
+  register: show_ip_result
+
+- name: output from show ip interface after remove
+  ansible.builtin.debug:
+    msg: '{{ show_ip_result.stdout }}'
+
+- name: check show ip interface output after remove
+  ansible.builtin.assert:
+    that:
+      - "'                       254.1.1.1/29                       N/A             N/A' not in show_ip_result.stdout"
+
+- name: remove same IP
+  community.sonic.interface_ip:
+    interface: Loopback0
+    state: absent
+    addresses:
+      - '254.1.1.1/29'
+  register: remove_same_ip_result
+
+- name: check remove IP result
+  ansible.builtin.assert:
+    that:
+      - remove_same_ip_result is not changed
+      - remove_same_ip_result.interface == 'Loopback0'
+      - "'254.1.1.1/29' not in remove_same_ip_result.addresses"

--- a/tests/unit/plugins/modules/test_interface_ip.py
+++ b/tests/unit/plugins/modules/test_interface_ip.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=disallowed-name
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import ipaddress
+from ansible_collections.community.sonic.plugins.modules import interface_ip
+
+
+class fake_configdb:
+    def __init__(self, tables):
+        self._tables = tables
+
+    def get_entry(self, table, key):
+        return self._tables.get(table, {}).get(key, {})
+
+    def set_entry(self, table, key, value):
+        tv = self._tables.get(table, {})
+        tv[key] = value
+        self._tables[table] = tv
+
+    def get_table(self, table):
+        return self._tables.get(table, {})
+
+
+def test_get_interface_table():
+    table = interface_ip.get_interface_table('Ethernet0.12')
+    assert table == 'VLAN_SUB_INTERFACE'
+
+    table = interface_ip.get_interface_table('Vlan3600')
+    assert table == 'VLAN_INTERFACE'
+
+    table = interface_ip.get_interface_table('Ethernet12')
+    assert table == 'INTERFACE'
+
+    table = interface_ip.get_interface_table('PortChannel2')
+    assert table == 'PORTCHANNEL_INTERFACE'
+
+    table = interface_ip.get_interface_table('Loopback100')
+    assert table == 'LOOPBACK_INTERFACE'
+
+    table = interface_ip.get_interface_table('eth0')
+    assert table is None
+
+
+def test_is_vlan_member():
+    tables = {
+        'VLAN_MEMBER': {
+            ('Vlan3600', 'Ethernet0'): {}
+        },
+    }
+    cdb = fake_configdb(tables)
+
+    is_member = interface_ip.is_vlan_member(cdb, 'Ethernet0')
+    assert is_member
+
+    is_member = interface_ip.is_vlan_member(cdb, 'Ethernet1')
+    assert not is_member
+
+
+def test_get_current_addresses():
+    tables = {
+        'VLAN_INTERFACE': {
+            ('Vlan3600', '10.2.0.3/24'): {}
+        }
+    }
+    test_addr = ipaddress.ip_interface('10.2.0.3/24')
+    cdb = fake_configdb(tables)
+
+    cur_addrs = interface_ip.get_current_addresses(cdb, 'VLAN_INTERFACE', 'Vlan3600')
+    assert cur_addrs == set((test_addr,))
+
+    cur_addrs = interface_ip.get_current_addresses(cdb, 'VLAN_INTERFACE', 'Vlan1')
+    assert len(cur_addrs) == 0


### PR DESCRIPTION
##### SUMMARY
Enables adding and removing addresses from interfaces. Doesn't support the management interface as it requires extra configuration.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
interface_ip
